### PR TITLE
Native serial port support & Fixes

### DIFF
--- a/Common/src/main/java/de/droiddrone/common/FcCommon.java
+++ b/Common/src/main/java/de/droiddrone/common/FcCommon.java
@@ -29,6 +29,10 @@ public class FcCommon {
     public static final byte FC_API_COMPATIBILITY_WARNING = 2;
     public static final byte FC_API_COMPATIBILITY_OK = 3;
 
+    public static final byte FC_PROTOCOL_AUTO = 0;
+    public static final byte FC_PROTOCOL_MSP = 1;
+    public static final byte FC_PROTOCOL_MAVLINK = 2;
+
     // MSP commands
     public static final short MSP_API_VERSION = 1;
     public static final short MSP_FC_VARIANT = 2;

--- a/Control/src/main/java/de/droiddrone/control/Config.java
+++ b/Control/src/main/java/de/droiddrone/control/Config.java
@@ -64,6 +64,7 @@ public class Config {
     private int rcRefreshRate;
     private int serialBaudRate;
     private int serialPortIndex;
+    private int fcProtocol;
     private int mavlinkTargetSysId;
     private int mavlinkGcsSysId;
     private final int[] rcChannelsMap = new int[FcCommon.MAX_SUPPORTED_RC_CHANNEL_COUNT];
@@ -121,6 +122,7 @@ public class Config {
         rcRefreshRate = parseInt(preferences.getString("rcRefreshRate", ""), 20);
         serialBaudRate = parseInt(preferences.getString("serialBaudRate", ""), 115200);
         serialPortIndex = parseInt(preferences.getString("serialPortIndex", ""), 0);
+        fcProtocol = parseInt(preferences.getString("fcProtocol", ""), FcCommon.FC_PROTOCOL_AUTO);
         mavlinkTargetSysId = parseInt(preferences.getString("mavlinkTargetSysId", ""), 1);
         mavlinkGcsSysId = parseInt(preferences.getString("mavlinkGcsSysId", ""), 255);
         ip = preferences.getString("ip", "");
@@ -271,6 +273,10 @@ public class Config {
 
     public int getSerialPortIndex() {
         return serialPortIndex;
+    }
+
+    public int getFcProtocol() {
+        return fcProtocol;
     }
 
     public int getMavlinkTargetSysId(){

--- a/Control/src/main/java/de/droiddrone/control/Config.java
+++ b/Control/src/main/java/de/droiddrone/control/Config.java
@@ -63,7 +63,9 @@ public class Config {
     private int telemetryRefreshRate;
     private int rcRefreshRate;
     private int serialBaudRate;
-    private int serialPortIndex;
+    private int usbSerialPortIndex;
+    private boolean useNativeSerialPort;
+    private String nativeSerialPort;
     private int fcProtocol;
     private int mavlinkTargetSysId;
     private int mavlinkGcsSysId;
@@ -121,7 +123,9 @@ public class Config {
         telemetryRefreshRate = parseInt(preferences.getString("telemetryRefreshRate", ""), 10);
         rcRefreshRate = parseInt(preferences.getString("rcRefreshRate", ""), 20);
         serialBaudRate = parseInt(preferences.getString("serialBaudRate", ""), 115200);
-        serialPortIndex = parseInt(preferences.getString("serialPortIndex", ""), 0);
+        usbSerialPortIndex = parseInt(preferences.getString("usbSerialPortIndex", ""), 0);
+        useNativeSerialPort = preferences.getBoolean("useNativeSerialPort", false);
+        nativeSerialPort = preferences.getString("nativeSerialPort", "/dev/ttyS0");
         fcProtocol = parseInt(preferences.getString("fcProtocol", ""), FcCommon.FC_PROTOCOL_AUTO);
         mavlinkTargetSysId = parseInt(preferences.getString("mavlinkTargetSysId", ""), 1);
         mavlinkGcsSysId = parseInt(preferences.getString("mavlinkGcsSysId", ""), 255);
@@ -271,8 +275,16 @@ public class Config {
         return serialBaudRate;
     }
 
-    public int getSerialPortIndex() {
-        return serialPortIndex;
+    public int getUsbSerialPortIndex() {
+        return usbSerialPortIndex;
+    }
+
+    public boolean isUseNativeSerialPort() {
+        return useNativeSerialPort;
+    }
+
+    public String getNativeSerialPort(){
+        return nativeSerialPort;
     }
 
     public int getFcProtocol() {

--- a/Control/src/main/java/de/droiddrone/control/Osd.java
+++ b/Control/src/main/java/de/droiddrone/control/Osd.java
@@ -1534,6 +1534,7 @@ public class Osd {
         this.directionToHome = directionToHome;
         osdStats.setTraveledDistance(traveledDistance);
         osdStats.setHomeDistance(distanceToHome);
+        if (lat == 0 && lon == 0) return;
         mapData.setDronePosition(latDeg, lonDeg, isArmed);
     }
 

--- a/Control/src/main/java/de/droiddrone/control/SettingsFragment.java
+++ b/Control/src/main/java/de/droiddrone/control/SettingsFragment.java
@@ -19,6 +19,7 @@ package de.droiddrone.control;
 
 import android.os.Bundle;
 import android.text.InputType;
+import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -55,9 +56,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 return true;
             });
         }
-        setNumericEditTextPreferenceSummary(findPreference("serialPortIndex"));
+        EditTextPreference usbSerialPortIndex = findPreference("usbSerialPortIndex");
         EditTextPreference mavlinkTargetSysId = findPreference("mavlinkTargetSysId");
         EditTextPreference mavlinkGcsSysId = findPreference("mavlinkGcsSysId");
+        setNumericEditTextPreferenceSummary(usbSerialPortIndex);
         setNumericEditTextPreferenceSummary(mavlinkTargetSysId);
         setNumericEditTextPreferenceSummary(mavlinkGcsSysId);
         setListPreferenceSummary(findPreference("usbCameraFrameFormat"));
@@ -71,6 +73,24 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         setListPreferenceSummary(findPreference("telemetryRefreshRate"));
         setListPreferenceSummary(findPreference("rcRefreshRate"));
         setListPreferenceSummary(findPreference("serialBaudRate"));
+        EditTextPreference nativeSerialPort = findPreference("nativeSerialPort");
+        if (nativeSerialPort != null){
+            nativeSerialPort.setSummaryProvider((Preference.SummaryProvider<EditTextPreference>) EditTextPreference::getText);
+            nativeSerialPort.setOnBindEditTextListener(editText -> {
+                editText.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+                editText.setMaxLines(1);
+            });
+        }
+        SwitchPreferenceCompat useNativeSerialPort = findPreference("useNativeSerialPort");
+        if (usbSerialPortIndex != null) {
+            usbSerialPortIndex.setEnabled(useNativeSerialPort == null || !useNativeSerialPort.isChecked());
+        }
+        if (useNativeSerialPort != null) {
+            useNativeSerialPort.setOnPreferenceChangeListener((preference, newValue) -> {
+                if (usbSerialPortIndex != null) usbSerialPortIndex.setEnabled(Boolean.FALSE.equals(newValue));
+                return true;
+            });
+        }
         ListPreference fcProtocol = findPreference("fcProtocol");
         if (fcProtocol != null){
             setListPreferenceSummary(fcProtocol);

--- a/Control/src/main/java/de/droiddrone/control/SettingsFragment.java
+++ b/Control/src/main/java/de/droiddrone/control/SettingsFragment.java
@@ -30,6 +30,8 @@ import androidx.preference.SwitchPreferenceCompat;
 
 import com.rarepebble.colorpicker.ColorPreference;
 
+import de.droiddrone.common.FcCommon;
+
 public class SettingsFragment extends PreferenceFragmentCompat {
     public static final int fragmentId = 3;
     private final MainActivity activity;
@@ -54,8 +56,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             });
         }
         setNumericEditTextPreferenceSummary(findPreference("serialPortIndex"));
-        setNumericEditTextPreferenceSummary(findPreference("mavlinkTargetSysId"));
-        setNumericEditTextPreferenceSummary(findPreference("mavlinkGcsSysId"));
+        EditTextPreference mavlinkTargetSysId = findPreference("mavlinkTargetSysId");
+        EditTextPreference mavlinkGcsSysId = findPreference("mavlinkGcsSysId");
+        setNumericEditTextPreferenceSummary(mavlinkTargetSysId);
+        setNumericEditTextPreferenceSummary(mavlinkGcsSysId);
         setListPreferenceSummary(findPreference("usbCameraFrameFormat"));
         setListPreferenceSummary(findPreference("cameraResolution"));
         setListPreferenceSummary(findPreference("cameraFps"));
@@ -67,6 +71,15 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         setListPreferenceSummary(findPreference("telemetryRefreshRate"));
         setListPreferenceSummary(findPreference("rcRefreshRate"));
         setListPreferenceSummary(findPreference("serialBaudRate"));
+        ListPreference fcProtocol = findPreference("fcProtocol");
+        if (fcProtocol != null){
+            setListPreferenceSummary(fcProtocol);
+            fcProtocol.setOnPreferenceChangeListener((preference, newValue) -> {
+                fcProtocolChanged(mavlinkTargetSysId, mavlinkGcsSysId, (String) newValue);
+                return true;
+            });
+            fcProtocolChanged(mavlinkTargetSysId, mavlinkGcsSysId, fcProtocol.getValue());
+        }
         Preference channelsMapping = findPreference("channelsMapping");
         if (channelsMapping != null) {
             channelsMapping.setOnPreferenceClickListener(preference -> {
@@ -74,6 +87,16 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 return true;
             });
         }
+    }
+
+    private void fcProtocolChanged(EditTextPreference mavlinkTargetSysId, EditTextPreference mavlinkGcsSysId, String value){
+        boolean isMsp = false;
+        try {
+            isMsp = Integer.parseInt(value) == FcCommon.FC_PROTOCOL_MSP;
+        }catch (Exception ignored){
+        }
+        if (mavlinkTargetSysId != null) mavlinkTargetSysId.setEnabled(!isMsp);
+        if (mavlinkGcsSysId != null) mavlinkGcsSysId.setEnabled(!isMsp);
     }
 
     @Override

--- a/Control/src/main/java/de/droiddrone/control/Udp.java
+++ b/Control/src/main/java/de/droiddrone/control/Udp.java
@@ -955,11 +955,13 @@ public class Udp {
             packetData.daos.writeByte(config.getTelemetryRefreshRate());
             packetData.daos.writeByte(config.getRcRefreshRate());
             packetData.daos.writeInt(config.getSerialBaudRate());
-            packetData.daos.writeByte(config.getSerialPortIndex());
+            packetData.daos.writeByte(config.getUsbSerialPortIndex());
+            packetData.daos.writeBoolean(config.isUseNativeSerialPort());
+            packetData.daos.writeUTF(config.getNativeSerialPort());
+            packetData.daos.writeByte(config.getFcProtocol());
             packetData.daos.writeBoolean(config.isUseUsbCamera());
             packetData.daos.writeByte(config.getUsbCameraFrameFormat());
             packetData.daos.writeBoolean(config.isUsbCameraReset());
-            packetData.daos.writeByte(config.getFcProtocol());
             packetData.daos.writeByte(config.getMavlinkTargetSysId());
             packetData.daos.writeByte(config.getMavlinkGcsSysId());
             udpSender.sendPacket(packetData.getData());

--- a/Control/src/main/java/de/droiddrone/control/Udp.java
+++ b/Control/src/main/java/de/droiddrone/control/Udp.java
@@ -959,6 +959,7 @@ public class Udp {
             packetData.daos.writeBoolean(config.isUseUsbCamera());
             packetData.daos.writeByte(config.getUsbCameraFrameFormat());
             packetData.daos.writeBoolean(config.isUsbCameraReset());
+            packetData.daos.writeByte(config.getFcProtocol());
             packetData.daos.writeByte(config.getMavlinkTargetSysId());
             packetData.daos.writeByte(config.getMavlinkGcsSysId());
             udpSender.sendPacket(packetData.getData());

--- a/Control/src/main/res/values/strings.xml
+++ b/Control/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="rc_refresh_rate">RC refresh rate</string>
     <string name="serial_baud_rate">Serial port baud rate</string>
     <string name="serial_port_index">Serial port index</string>
+    <string name="fc_protocol">FC protocol</string>
     <string name="mavlink_target_sysid">Mavlink target system ID</string>
     <string name="mavlink_gcs_sysid">Mavlink GCS system ID</string>
     <string name="version_mismatch">Control/Flight version mismatch!</string>
@@ -258,5 +259,17 @@
     <string-array name="videoRecorderCodecValues">
         <item>0</item>
         <item>1</item>
+    </string-array>
+
+    <string-array name="fcProtocolEntries">
+        <item>Auto</item>
+        <item>MSP</item>
+        <item>Mavlink</item>
+    </string-array>
+
+    <string-array name="fcProtocolValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
     </string-array>
 </resources>

--- a/Control/src/main/res/values/strings.xml
+++ b/Control/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="telemetry_refresh_rate">Telemetry refresh rate</string>
     <string name="rc_refresh_rate">RC refresh rate</string>
     <string name="serial_baud_rate">Serial port baud rate</string>
-    <string name="serial_port_index">Serial port index</string>
+    <string name="usb_serial_port_index">USB Serial port index</string>
     <string name="fc_protocol">FC protocol</string>
     <string name="mavlink_target_sysid">Mavlink target system ID</string>
     <string name="mavlink_gcs_sysid">Mavlink GCS system ID</string>
@@ -66,6 +66,10 @@
     <string name="usb_camera_frame_format">USB camera frame format</string>
     <string name="usb_camera_reset_to_defaults">USB camera - reset to defaults on connecting</string>
     <string name="permission_rationale_location">Access to the location service is required to display your current location on the map.</string>
+    <string name="use_native_serial">Use native serial port</string>
+    <string name="native_serial_on">On - use native serial port connected to the UART</string>
+    <string name="native_serial_off">Off - use USB serial</string>
+    <string name="native_serial_port_address">Native serial port address</string>
 
     <string-array name="cameraResolutionsEntries">
         <item>3840x2160</item>

--- a/Control/src/main/res/xml/preferences.xml
+++ b/Control/src/main/res/xml/preferences.xml
@@ -194,6 +194,12 @@
             app:key="serialPortIndex"
             app:defaultValue="0"
             app:title="@string/serial_port_index" />
+        <ListPreference
+            app:key="fcProtocol"
+            app:title="@string/fc_protocol"
+            app:entries="@array/fcProtocolEntries"
+            app:entryValues="@array/fcProtocolValues"
+            app:defaultValue="0"/>
         <EditTextPreference
             app:key="mavlinkTargetSysId"
             app:defaultValue="1"

--- a/Control/src/main/res/xml/preferences.xml
+++ b/Control/src/main/res/xml/preferences.xml
@@ -190,10 +190,21 @@
             app:entries="@array/serialBaudRateEntries"
             app:entryValues="@array/serialBaudRateValues"
             app:defaultValue="115200"/>
+        <SwitchPreferenceCompat
+            app:key="useNativeSerialPort"
+            app:summaryOn="@string/native_serial_on"
+            app:summaryOff="@string/native_serial_off"
+            app:defaultValue="false"
+            app:title="@string/use_native_serial"/>
         <EditTextPreference
-            app:key="serialPortIndex"
+            app:key="usbSerialPortIndex"
             app:defaultValue="0"
-            app:title="@string/serial_port_index" />
+            app:title="@string/usb_serial_port_index" />
+        <EditTextPreference
+            app:key="nativeSerialPort"
+            app:defaultValue="/dev/ttyS0"
+            app:dependency="useNativeSerialPort"
+            app:title="@string/native_serial_port_address" />
         <ListPreference
             app:key="fcProtocol"
             app:title="@string/fc_protocol"

--- a/Flight/build.gradle
+++ b/Flight/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.preference:preference:1.2.1"
     implementation 'com.github.mik3y:usb-serial-for-android:3.8.0'
+    implementation 'io.github.xmaihh:serialport:2.1.1'
     implementation 'com.google.android.material:material:1.12.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'

--- a/Flight/src/main/java/de/droiddrone/flight/Config.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Config.java
@@ -23,6 +23,7 @@ import android.content.SharedPreferences;
 import androidx.preference.PreferenceManager;
 
 import de.droiddrone.common.DataReader;
+import de.droiddrone.common.FcCommon;
 import de.droiddrone.common.MediaCommon;
 import de.droiddrone.common.UdpCommon;
 
@@ -53,6 +54,7 @@ public class Config {
     private int rcRefreshRate;
     private int serialBaudRate;
     private int serialPortIndex;
+    private int fcProtocol;
     private int mavlinkTargetSysId;
     private int mavlinkGcsSysId;
     private boolean connectOnStartup;
@@ -165,6 +167,10 @@ public class Config {
         return serialPortIndex;
     }
 
+    public int getFcProtocol() {
+        return fcProtocol;
+    }
+
     public short getMavlinkTargetSysId() {
         return (short)mavlinkTargetSysId;
     }
@@ -201,6 +207,7 @@ public class Config {
             useUsbCamera = buffer.readBoolean();
             usbCameraFrameFormat = buffer.readByte();
             usbCameraReset = buffer.readBoolean();
+            fcProtocol = buffer.readByte();
             mavlinkTargetSysId = buffer.readUnsignedByteAsInt();
             mavlinkGcsSysId = buffer.readUnsignedByteAsInt();
             if (!updateConfig()) return -2;
@@ -237,6 +244,7 @@ public class Config {
         rcRefreshRate = preferences.getInt("rcRefreshRate", 20);
         serialBaudRate = preferences.getInt("serialBaudRate", 115200);
         serialPortIndex = preferences.getInt("serialPortIndex", 0);
+        fcProtocol = preferences.getInt("fcProtocol", FcCommon.FC_PROTOCOL_AUTO);
         mavlinkTargetSysId = preferences.getInt("mavlinkTargetSysId", 1);
         mavlinkGcsSysId = preferences.getInt("mavlinkGcsSysId", 255);
         connectOnStartup = preferences.getBoolean("connectOnStartup", false);
@@ -282,6 +290,7 @@ public class Config {
         editor.putInt("rcRefreshRate", rcRefreshRate);
         editor.putInt("serialBaudRate", serialBaudRate);
         editor.putInt("serialPortIndex", serialPortIndex);
+        editor.putInt("fcProtocol", fcProtocol);
         editor.putInt("mavlinkTargetSysId", mavlinkTargetSysId);
         editor.putInt("mavlinkGcsSysId", mavlinkGcsSysId);
         connectOnStartup = activity.cbConnectOnStartup.isChecked();

--- a/Flight/src/main/java/de/droiddrone/flight/Config.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Config.java
@@ -53,7 +53,9 @@ public class Config {
     private int telemetryRefreshRate;
     private int rcRefreshRate;
     private int serialBaudRate;
-    private int serialPortIndex;
+    private int usbSerialPortIndex;
+    private boolean useNativeSerialPort;
+    private String nativeSerialPort;
     private int fcProtocol;
     private int mavlinkTargetSysId;
     private int mavlinkGcsSysId;
@@ -163,8 +165,16 @@ public class Config {
         return serialBaudRate;
     }
 
-    public int getSerialPortIndex() {
-        return serialPortIndex;
+    public int getUsbSerialPortIndex() {
+        return usbSerialPortIndex;
+    }
+
+    public boolean isUseNativeSerialPort() {
+        return useNativeSerialPort;
+    }
+
+    public String getNativeSerialPort(){
+        return nativeSerialPort;
     }
 
     public int getFcProtocol() {
@@ -203,11 +213,13 @@ public class Config {
             telemetryRefreshRate = buffer.readUnsignedByteAsInt();
             rcRefreshRate = buffer.readUnsignedByteAsInt();
             serialBaudRate = buffer.readInt();
-            serialPortIndex = buffer.readByte();
+            usbSerialPortIndex = buffer.readByte();
+            useNativeSerialPort = buffer.readBoolean();
+            nativeSerialPort = buffer.readUTF();
+            fcProtocol = buffer.readByte();
             useUsbCamera = buffer.readBoolean();
             usbCameraFrameFormat = buffer.readByte();
             usbCameraReset = buffer.readBoolean();
-            fcProtocol = buffer.readByte();
             mavlinkTargetSysId = buffer.readUnsignedByteAsInt();
             mavlinkGcsSysId = buffer.readUnsignedByteAsInt();
             if (!updateConfig()) return -2;
@@ -243,7 +255,9 @@ public class Config {
         telemetryRefreshRate = preferences.getInt("telemetryRefreshRate", 10);
         rcRefreshRate = preferences.getInt("rcRefreshRate", 20);
         serialBaudRate = preferences.getInt("serialBaudRate", 115200);
-        serialPortIndex = preferences.getInt("serialPortIndex", 0);
+        usbSerialPortIndex = preferences.getInt("usbSerialPortIndex", 0);
+        useNativeSerialPort = preferences.getBoolean("useNativeSerialPort", false);
+        nativeSerialPort = preferences.getString("nativeSerialPort", "/dev/ttyS0");
         fcProtocol = preferences.getInt("fcProtocol", FcCommon.FC_PROTOCOL_AUTO);
         mavlinkTargetSysId = preferences.getInt("mavlinkTargetSysId", 1);
         mavlinkGcsSysId = preferences.getInt("mavlinkGcsSysId", 255);
@@ -289,7 +303,9 @@ public class Config {
         editor.putInt("telemetryRefreshRate", telemetryRefreshRate);
         editor.putInt("rcRefreshRate", rcRefreshRate);
         editor.putInt("serialBaudRate", serialBaudRate);
-        editor.putInt("serialPortIndex", serialPortIndex);
+        editor.putInt("usbSerialPortIndex", usbSerialPortIndex);
+        editor.putBoolean("useNativeSerialPort", useNativeSerialPort);
+        editor.putString("nativeSerialPort", nativeSerialPort);
         editor.putInt("fcProtocol", fcProtocol);
         editor.putInt("mavlinkTargetSysId", mavlinkTargetSysId);
         editor.putInt("mavlinkGcsSysId", mavlinkGcsSysId);

--- a/Flight/src/main/java/de/droiddrone/flight/DDService.java
+++ b/Flight/src/main/java/de/droiddrone/flight/DDService.java
@@ -162,12 +162,13 @@ public class DDService extends Service {
                 if (!isConnected && connectionMode == 0) udp.sendConnect();
                 serialPortStatus = serial.getStatus();
                 if (serialPortStatus == Serial.STATUS_SERIAL_PORT_ERROR){
-                    if (serial != null && (msp != null || mavlink != null)) {
+                    if (serial != null && (msp != null && mavlink != null)) {
+                        fcInfo = null;
                         serial.initialize(msp, mavlink);
                     }
                 }
                 if (serial != null && fcInfo == null) {
-                    if (serial.isArduPilot()){
+                    if (serial.isMavlink()){
                         if (mavlink != null) fcInfo = mavlink.getFcInfo();
                     } else {
                         if (msp != null) fcInfo = msp.getFcInfo();

--- a/Flight/src/main/java/de/droiddrone/flight/Mavlink.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Mavlink.java
@@ -1014,7 +1014,7 @@ public class Mavlink {
 
     public void close(){
         threadsId++;
-        disableIntervalMessages();
+        if (isInitialized()) disableIntervalMessages();
         apiVersionMajor = -1;
         apiVersionMinor = -1;
         fcVersionMajor = -1;
@@ -1026,5 +1026,6 @@ public class Mavlink {
         telemetryOutputBuffer.clear();
         serialRawData.clear();
         batteryCellCountDetected = 0;
+        fcInfo = null;
     }
 }

--- a/Flight/src/main/java/de/droiddrone/flight/Mavlink.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Mavlink.java
@@ -301,10 +301,7 @@ public class Mavlink {
         if (channels == null || fcParams == null) return;
         int rcCount = channels.length;
         long current = System.currentTimeMillis();
-        if (current - rcLastFrame < rcMinPeriod){
-            rcLastFrame = current;
-            return;
-        }
+        if (current - rcLastFrame < rcMinPeriod) return;
         rcLastFrame = current;
         checkRcOptionsChannels(channels);
         short roll = channels[0];

--- a/Flight/src/main/java/de/droiddrone/flight/Msp.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Msp.java
@@ -680,10 +680,7 @@ public class Msp {
     public void setRawRc(short[] rcChannels){
         if (rcChannels == null || rcChannels.length > FcCommon.MAX_SUPPORTED_RC_CHANNEL_COUNT) return;
         long current = System.currentTimeMillis();
-        if (current - rcLastFrame < rcMinPeriod){
-            rcLastFrame = current;
-            return;
-        }
+        if (current - rcLastFrame < rcMinPeriod) return;
         rcLastFrame = current;
         DataWriter writer = new DataWriter(false);
         short[] mappedChannels = processRxMap(rcChannels);

--- a/Flight/src/main/java/de/droiddrone/flight/Msp.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Msp.java
@@ -169,6 +169,15 @@ public class Msp {
         osdConfig = null;
         telemetryOutputBuffer.clear();
         serialRawData.clear();
+        fcVariant = FcInfo.FC_VARIANT_UNKNOWN;
+        apiProtocolVersion = -1;
+        apiVersionMajor = -1;
+        apiVersionMinor = -1;
+        fcVersionMajor = -1;
+        fcVersionMinor = -1;
+        fcVersionPatchLevel = -1;
+        platformType = -1;
+        fcInfo = null;
     }
 
     private final Runnable mspRun = new Runnable() {

--- a/Flight/src/main/java/de/droiddrone/flight/Msp.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Msp.java
@@ -174,7 +174,6 @@ public class Msp {
     private final Runnable mspRun = new Runnable() {
         public void run() {
             final int id = threadsId;
-            final int timerDelayMs = 1000 / config.getTelemetryRefreshRate();
             int timerDiv = 0;
             log("Start MSP thread - OK");
             while (id == threadsId) {
@@ -187,7 +186,7 @@ public class Msp {
                         if (apiVersionMajor == -1) getMspApiVersion();
                         if (fcVersionMajor == -1) getFcVersion();
                         if (platformType == -1 && fcVariant != 0) getMixerConfig();
-                        Thread.sleep(timerDelayMs);
+                        Thread.sleep(1000 / config.getTelemetryRefreshRate());
                         continue;
                     }
 
@@ -243,7 +242,7 @@ public class Msp {
                     }
 
                     getAttitude();
-                    Thread.sleep(timerDelayMs);
+                    Thread.sleep(1000 / config.getTelemetryRefreshRate());
                 } catch (Exception e) {
                     log("MSP thread error: " + e);
                 }

--- a/Flight/src/main/java/de/droiddrone/flight/Serial.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Serial.java
@@ -34,8 +34,11 @@ import com.hoho.android.usbserial.driver.UsbSerialProber;
 import java.io.IOException;
 import java.util.List;
 
+import android_serialport_api.SerialPortFinder;
 import de.droiddrone.common.FcInfo;
 import de.droiddrone.common.FcCommon;
+import tp.xmaihh.serialport.SerialHelper;
+import tp.xmaihh.serialport.bean.ComBean;
 
 public class Serial {
     public static final String ACTION_USB_PERMISSION = "de.droiddrone.flight.USB_PERMISSION";
@@ -50,6 +53,15 @@ public class Serial {
     private static final int serialDataBits = 8;
     private static final int serialPortReadWriteTimeoutMs = 100;
     private static final int serialMaxBufferSize = 2048;
+    // native serial
+    private static final int nativeSerialParityNone = 0;
+    private static final int nativeSerialParityOdd = 1;
+    private static final int nativeSerialParityEven = 2;
+    private static final int nativeSerialParitySpace = 3;
+    private static final int nativeSerialParityMark = 4;
+    private static final int nativeSerialFlowControlNone = 0;
+    private static final int nativeSerialFlowControlRtsCts = 1;
+    private static final int nativeSerialFlowControlXonXoff = 2;
     private final Context context;
     private final Config config;
     private final UsbManager manager;
@@ -61,6 +73,7 @@ public class Serial {
     private int threadsId;
     private int status;
     private boolean isMavlink;
+    private SerialHelper serialHelper;
 
     public Serial(Context context, Config config){
         this.context = context;
@@ -96,11 +109,18 @@ public class Serial {
             status = STATUS_DEVICE_NOT_CONNECTED;
             while (id == threadsId) {
                 try {
-                    if (findDevice()) {
-                        if (checkPermission()) {
-                            if (openPort()) {
-                                log("Serial port is opened");
-                                return;
+                    if (config.isUseNativeSerialPort()){
+                        if (openNativeSerialPort()) {
+                            log("Native serial port is opened");
+                            return;
+                        }
+                    }else {
+                        if (findDevice()) {
+                            if (checkPermission()) {
+                                if (openUsbSerialPort()) {
+                                    log("USB Serial port is opened");
+                                    return;
+                                }
                             }
                         }
                     }
@@ -130,18 +150,7 @@ public class Serial {
                     || FcInfo.ARDUPILOT_ID.equals(name) || FcInfo.ARDUPILOT_NAME.equals(name)) {
                 driver = availableDrivers.get(i);
                 status = STATUS_DEVICE_FOUND;
-                switch (config.getFcProtocol()){
-                    case FcCommon.FC_PROTOCOL_AUTO:
-                    default:
-                        isMavlink = FcInfo.ARDUPILOT_ID.equals(name) || FcInfo.ARDUPILOT_NAME.equals(name);
-                        break;
-                    case FcCommon.FC_PROTOCOL_MSP:
-                        isMavlink = false;
-                        break;
-                    case FcCommon.FC_PROTOCOL_MAVLINK:
-                        isMavlink = true;
-                        break;
-                }
+                setFcProtocol(name);
                 log("Serial device manufacturer name: " + name);
                 log("Serial device driver version: " + driver.getDevice().getVersion());
                 log("Serial device driver vendorId: " + driver.getDevice().getVendorId());
@@ -151,6 +160,36 @@ public class Serial {
         }
         status = STATUS_DEVICE_NOT_CONNECTED;
         return false;
+    }
+
+    private void setFcProtocol(String UsbDeviceManufacturerName){
+        switch (config.getFcProtocol()){
+            case FcCommon.FC_PROTOCOL_AUTO:
+            default:
+                isMavlink = FcInfo.ARDUPILOT_ID.equals(UsbDeviceManufacturerName) || FcInfo.ARDUPILOT_NAME.equals(UsbDeviceManufacturerName);
+                break;
+            case FcCommon.FC_PROTOCOL_MSP:
+                isMavlink = false;
+                break;
+            case FcCommon.FC_PROTOCOL_MAVLINK:
+                isMavlink = true;
+                break;
+        }
+    }
+
+    private boolean checkFcProtocol(){
+        if (isMavlink){
+            if (config.getFcProtocol() == FcCommon.FC_PROTOCOL_MSP){
+                status = STATUS_SERIAL_PORT_ERROR;
+                return false;
+            }
+        }else{
+            if (config.getFcProtocol() == FcCommon.FC_PROTOCOL_MAVLINK){
+                status = STATUS_SERIAL_PORT_ERROR;
+                return false;
+            }
+        }
+        return true;
     }
 
     @SuppressLint("UnspecifiedImmutableFlag")
@@ -174,7 +213,58 @@ public class Serial {
         return false;
     }
 
-    private boolean openPort(){
+    private boolean openNativeSerialPort(){
+        if (status == STATUS_SERIAL_PORT_OPENED) return true;
+        setFcProtocol(null);
+        if (serialHelper != null) serialHelper.close();
+        try {
+            SerialPortFinder serialPortFinder = new SerialPortFinder();
+            String[] ports = serialPortFinder.getAllDevicesPath();
+            if (ports != null) {
+                for (String port : ports) {
+                    log("Native serial port found: " + port);
+                }
+            }
+            serialHelper = new SerialHelper(config.getNativeSerialPort(), config.getSerialBaudRate()) {
+                @Override
+                protected void onDataReceived(ComBean comBean) {
+                    try {
+                        byte[] buf = comBean.bRec;
+                        int size = buf.length;
+                        if (!checkFcProtocol()) return;
+                        if (size > 0){
+                            status = STATUS_SERIAL_PORT_OPENED;
+                            if (isMavlink){
+                                mavlink.addData(buf, size);
+                            } else {
+                                msp.addData(buf, size);
+                            }
+                        }
+                    } catch (Exception e) {
+                        log("Native serial reader error: " + e);
+                    }
+                }
+            };
+            serialHelper.setStopBits(1);
+            serialHelper.setDataBits(serialDataBits);
+            serialHelper.setParity(nativeSerialParityNone);
+            serialHelper.setFlowCon(nativeSerialFlowControlNone);
+            serialHelper.open();
+            if (isMavlink){
+                if (!mavlink.isInitialized()) mavlink.initialize();
+            } else {
+                if (!msp.isInitialized()) msp.initialize();
+            }
+        }catch (Exception e){
+            status = STATUS_SERIAL_PORT_ERROR;
+            log("Native serial port error: " + e);
+            return false;
+        }
+        status = STATUS_SERIAL_PORT_OPENED;
+        return true;
+    }
+
+    private boolean openUsbSerialPort(){
         if (status == STATUS_SERIAL_PORT_OPENED) return true;
         if (driver == null){
             status = STATUS_DEVICE_NOT_CONNECTED;
@@ -190,7 +280,7 @@ public class Serial {
             status = STATUS_USB_PERMISSION_DENIED;
             return false;
         }
-        port = driver.getPorts().get(config.getSerialPortIndex());
+        port = driver.getPorts().get(config.getUsbSerialPortIndex());
         try {
             port.open(connection);
             port.setParameters(config.getSerialBaudRate(), serialDataBits, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE);
@@ -219,21 +309,11 @@ public class Serial {
             int serialErrors = 0;
             byte[] buf = new byte[serialMaxBufferSize];
             status = STATUS_SERIAL_PORT_OPENED;
-            log("Start serial reader thread - OK");
+            log("Start USB serial reader thread - OK");
             while (id == threadsId) {
                 try {
                     int size = port.read(buf, serialPortReadWriteTimeoutMs);
-                    if (isMavlink){
-                        if (config.getFcProtocol() == FcCommon.FC_PROTOCOL_MSP){
-                            status = STATUS_SERIAL_PORT_ERROR;
-                            continue;
-                        }
-                    }else{
-                        if (config.getFcProtocol() == FcCommon.FC_PROTOCOL_MAVLINK){
-                            status = STATUS_SERIAL_PORT_ERROR;
-                            continue;
-                        }
-                    }
+                    if (!checkFcProtocol()) continue;
                     if (size > 0){
                         serialErrors = 0;
                         status = STATUS_SERIAL_PORT_OPENED;
@@ -258,20 +338,28 @@ public class Serial {
     };
 
     public void writeDataMsp(byte[] data, boolean checkMspCompatibility){
-        if (status != STATUS_SERIAL_PORT_OPENED || data == null || port == null || !port.isOpen()) return;
+        if (status != STATUS_SERIAL_PORT_OPENED || data == null) return;
         if (checkMspCompatibility && FcCommon.getFcApiCompatibilityLevel(msp.getFcInfo()) != FcCommon.FC_API_COMPATIBILITY_OK
                 && FcCommon.getFcApiCompatibilityLevel(msp.getFcInfo()) != FcCommon.FC_API_COMPATIBILITY_WARNING) return;
         try {
-            port.write(data, serialPortReadWriteTimeoutMs);
+            if (config.isUseNativeSerialPort()){
+                if (serialHelper != null && serialHelper.isOpen()) serialHelper.send(data);
+            }else{
+                if (port != null && port.isOpen()) port.write(data, serialPortReadWriteTimeoutMs);
+            }
         } catch (IOException e) {
             log("Serial writeDataMsp error: " + e);
         }
     }
 
     public void writeDataMavlink(byte[] data){
-        if (status != STATUS_SERIAL_PORT_OPENED || data == null || port == null || !port.isOpen()) return;
+        if (status != STATUS_SERIAL_PORT_OPENED || data == null) return;
         try {
-            port.write(data, serialPortReadWriteTimeoutMs);
+            if (config.isUseNativeSerialPort()){
+                if (serialHelper != null && serialHelper.isOpen()) serialHelper.send(data);
+            }else{
+                if (port != null && port.isOpen()) port.write(data, serialPortReadWriteTimeoutMs);
+            }
         } catch (IOException e) {
             log("Serial writeDataMavlink error: " + e);
         }
@@ -288,6 +376,11 @@ public class Serial {
         try {
             if (port != null) port.close();
         } catch (IOException e) {
+            //
+        }
+        try {
+            if (serialHelper != null) serialHelper.close();
+        } catch (Exception e) {
             //
         }
         if (connection != null) connection.close();

--- a/Flight/src/main/java/de/droiddrone/flight/Udp.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Udp.java
@@ -186,9 +186,9 @@ public class Udp {
         public void run() {
             final int id = udpThreadsId;
             log("Start buffer thread - OK");
+            SavedPacket packet = null;
             while (socket != null && !socket.isClosed() && id == udpThreadsId) {
                 try {
-                    SavedPacket packet;
                     do{
                         packet = receiverBuffer.getNextPacket();
                         if (packet != null) processData(packet);
@@ -196,7 +196,11 @@ public class Udp {
                     receiverBuffer.processTimer();
                     Thread.sleep(1);
                 } catch (Exception e) {
-                    log("Receiver buffer error: " + e);
+                    if (packet != null) {
+                        log("Receiver buffer error: " + e + ", packetName: " + packet.packetName);
+                    }else{
+                        log("Receiver buffer error: " + e);
+                    }
                 }
             }
         }

--- a/Flight/src/main/res/xml/device_filter.xml
+++ b/Flight/src/main/res/xml/device_filter.xml
@@ -3,6 +3,8 @@
     <!-- FC -->
     <usb-device vendor-id="1155" product-id="22336" />
     <usb-device vendor-id="4617" product-id="22337" />
+    <!-- USB to UART/TTL converter -->
+    <usb-device vendor-id="6790" product-id="29987" />
     <!-- USB UVC Camera -->
     <usb-device class="239" subclass="2" />
 </resources>


### PR DESCRIPTION
Native serial port support - If you are using an Android mini PC with UART port, you can connect it with FC's MSP/Mavlink enabled UART directly. You should select the FC protocol (MSP or Mavlink) in the settings - automatic selection only works if the main USB port of the FC is used. After changing the serial port settings, the flight app must be reconnected.