### PR TITLE
MavlinkUdpBridge - add redirectFromControlDevice mode

### DIFF
--- a/Common/src/main/java/de/droiddrone/common/SettingsCommon.java
+++ b/Common/src/main/java/de/droiddrone/common/SettingsCommon.java
@@ -96,6 +96,7 @@ public class SettingsCommon {
         public static final int disabled = 0;
         public static final int connectedIp = 1;
         public static final int specificIp = 2;
+        public static final int redirectFromControlDevice = 3;
     }
 
     public static class VrMode {

--- a/Common/src/main/java/de/droiddrone/common/UdpCommon.java
+++ b/Common/src/main/java/de/droiddrone/common/UdpCommon.java
@@ -48,6 +48,7 @@ public class UdpCommon {
     public static final byte VersionMismatch = 23;
     public static final byte RcFrame = 24;
     public static final byte ChangeCamera = 25;
+    public static final byte MavlinkRawPacket = 26;// MavlinkUdpBridge.redirectFromControlDevice mode
     //endregion
 
     public static boolean isPacketNumbered(byte packetName){
@@ -68,6 +69,7 @@ public class UdpCommon {
             case ConfigReceived:
             case VersionMismatch:
             case ChangeCamera:
+            case MavlinkRawPacket:
                 return true;
             default:
                 return false;

--- a/Control/src/main/java/de/droiddrone/control/Config.java
+++ b/Control/src/main/java/de/droiddrone/control/Config.java
@@ -87,6 +87,7 @@ public class Config {
     private int mavlinkUdpBridgePort;
     private boolean decoderConfigChanged;
     private boolean videoFrameOrientationChanged;
+    private boolean mavlinkUdpBridgeConfigChanged;
 
     public Config(MainActivity activity, int versionCode) {
         this.activity = activity;
@@ -109,6 +110,14 @@ public class Config {
 
     public void videoFrameOrientationUpdated(){
         videoFrameOrientationChanged = false;
+    }
+
+    public boolean isMavlinkUdpBridgeConfigChanged(){
+        return mavlinkUdpBridgeConfigChanged;
+    }
+
+    public void mavlinkUdpBridgeConfigUpdated(){
+        mavlinkUdpBridgeConfigChanged = false;
     }
 
     private void loadConfig(){
@@ -171,9 +180,17 @@ public class Config {
         fcProtocol = Utils.parseInt(preferences.getString("fcProtocol", ""), SettingsCommon.fcProtocol);
         mavlinkTargetSysId = Utils.parseInt(preferences.getString("mavlinkTargetSysId", ""), SettingsCommon.mavlinkTargetSysId);
         mavlinkGcsSysId = Utils.parseInt(preferences.getString("mavlinkGcsSysId", ""), SettingsCommon.mavlinkGcsSysId);
-        mavlinkUdpBridge = Utils.parseInt(preferences.getString("mavlinkUdpBridge", ""), SettingsCommon.mavlinkUdpBridge);
-        mavlinkUdpBridgeIp = preferences.getString("mavlinkUdpBridgeIp", SettingsCommon.mavlinkUdpBridgeIp);
-        mavlinkUdpBridgePort = Utils.parseInt(preferences.getString("mavlinkUdpBridgePort", ""), SettingsCommon.mavlinkUdpBridgePort);
+        int mavlinkUdpBridge = Utils.parseInt(preferences.getString("mavlinkUdpBridge", ""), SettingsCommon.mavlinkUdpBridge);
+        String mavlinkUdpBridgeIp = preferences.getString("mavlinkUdpBridgeIp", SettingsCommon.mavlinkUdpBridgeIp);
+        int mavlinkUdpBridgePort = Utils.parseInt(preferences.getString("mavlinkUdpBridgePort", ""), SettingsCommon.mavlinkUdpBridgePort);
+        if (mavlinkUdpBridge != this.mavlinkUdpBridge
+                || !mavlinkUdpBridgeIp.equals(this.mavlinkUdpBridgeIp)
+                || mavlinkUdpBridgePort != this.mavlinkUdpBridgePort) {
+            mavlinkUdpBridgeConfigChanged = true;
+        }
+        this.mavlinkUdpBridge = mavlinkUdpBridge;
+        this.mavlinkUdpBridgeIp = mavlinkUdpBridgeIp;
+        this.mavlinkUdpBridgePort = mavlinkUdpBridgePort;
         boolean invertVideoAxisX = preferences.getBoolean("invertVideoAxisX", SettingsCommon.invertVideoAxisX);
         boolean invertVideoAxisY = preferences.getBoolean("invertVideoAxisY", SettingsCommon.invertVideoAxisY);
         if (invertVideoAxisX != this.invertVideoAxisX || invertVideoAxisY != this.invertVideoAxisY) videoFrameOrientationChanged = true;

--- a/Control/src/main/java/de/droiddrone/control/SettingsFragment.java
+++ b/Control/src/main/java/de/droiddrone/control/SettingsFragment.java
@@ -106,7 +106,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         if (mavlinkUdpBridge != null) {
             mavlinkUdpBridge.setOnPreferenceChangeListener((preference, newValue) -> {
                 int value = Utils.parseInt((String) newValue, SettingsCommon.mavlinkUdpBridge);
-                if (mavlinkUdpBridgeIp != null) mavlinkUdpBridgeIp.setEnabled(value == SettingsCommon.MavlinkUdpBridge.specificIp);
+                if (mavlinkUdpBridgeIp != null){
+                    mavlinkUdpBridgeIp.setEnabled(value == SettingsCommon.MavlinkUdpBridge.specificIp
+                            || value == SettingsCommon.MavlinkUdpBridge.redirectFromControlDevice);
+                }
                 if (mavlinkUdpBridgePort != null) mavlinkUdpBridgePort.setEnabled(value != SettingsCommon.MavlinkUdpBridge.disabled);
                 return true;
             });
@@ -190,7 +193,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             mavlinkUdpBridge.setEnabled(!isMsp);
             mavlinkUdpBridgeValue = Utils.parseInt(mavlinkUdpBridge.getValue(), SettingsCommon.mavlinkUdpBridge);
         }
-        if (mavlinkUdpBridgeIp != null) mavlinkUdpBridgeIp.setEnabled(!isMsp && mavlinkUdpBridgeValue == SettingsCommon.MavlinkUdpBridge.specificIp);
+        if (mavlinkUdpBridgeIp != null) {
+            mavlinkUdpBridgeIp.setEnabled(!isMsp &&
+                    (mavlinkUdpBridgeValue == SettingsCommon.MavlinkUdpBridge.specificIp
+                            || mavlinkUdpBridgeValue == SettingsCommon.MavlinkUdpBridge.redirectFromControlDevice));
+        }
         if (mavlinkUdpBridgePort != null) mavlinkUdpBridgePort.setEnabled(!isMsp && mavlinkUdpBridgeValue != SettingsCommon.MavlinkUdpBridge.disabled);
     }
 

--- a/Control/src/main/res/values/strings.xml
+++ b/Control/src/main/res/values/strings.xml
@@ -338,11 +338,13 @@
         <item>Disabled</item>
         <item>Send to connected IP</item>
         <item>Send to specific IP</item>
+        <item>Send to control device and then forward to IP</item>
     </string-array>
 
     <string-array name="mavlinkUdpBridgeValues">
         <item>0</item>
         <item>1</item>
         <item>2</item>
+        <item>3</item>
     </string-array>
 </resources>

--- a/Flight/src/main/java/de/droiddrone/flight/DDService.java
+++ b/Flight/src/main/java/de/droiddrone/flight/DDService.java
@@ -113,6 +113,7 @@ public class DDService extends Service {
         if (udp != null) udp.close();
         udp = new Udp(destIp, port, key, connectionMode, streamEncoder, mp4Recorder, cameraManager, msp, mavlink, phoneTelemetry, MainActivity.config, serial, mavlinkUdpBridge);
         mavlinkUdpBridge.setUdp(udp);
+        mavlink.setUdp(udp);
         Thread t1 = new Thread(() -> {
             if (!udp.initialize()){
                 log("UDP initialize error.");
@@ -163,7 +164,8 @@ public class DDService extends Service {
                 }
                 isConnected = udp.isConnected();
                 if (isConnected){
-                    if (MainActivity.config.getMavlinkUdpBridge() != SettingsCommon.MavlinkUdpBridge.disabled) {
+                    if (MainActivity.config.getMavlinkUdpBridge() != SettingsCommon.MavlinkUdpBridge.disabled
+                            && MainActivity.config.getMavlinkUdpBridge() != SettingsCommon.MavlinkUdpBridge.redirectFromControlDevice) {
                         if (!mavlinkUdpBridge.isInitialized() && mavlink.isInitialized()) {
                             mavlinkUdpBridge.initialize();
                         }

--- a/Flight/src/main/java/de/droiddrone/flight/Udp.java
+++ b/Flight/src/main/java/de/droiddrone/flight/Udp.java
@@ -428,6 +428,27 @@ public class Udp {
                 t1.start();
                 break;
             }
+            case UdpCommon.MavlinkRawPacket:
+            {
+                int dataSize = buffer.getRemaining();
+                byte[] buf = new byte[dataSize];
+                int read = buffer.read(buf, 0, dataSize);
+                if (read == dataSize) {
+                    mavlink.processReceivedUdpData(buf);
+                }
+                break;
+            }
+        }
+    }
+
+    public void sendMavlinkPacket(byte[] buf) {
+        if (socket == null || socket.isClosed() || buf == null) return;
+        try {
+            UdpPacketData packetData = new UdpPacketData(UdpCommon.MavlinkRawPacket);
+            packetData.daos.write(buf, 0, buf.length);
+            udpSender.sendPacket(packetData.getData());
+        } catch (Exception e) {
+            log("sendMavlinkPacket error: " + e);
         }
     }
 
@@ -443,7 +464,8 @@ public class Udp {
         }
         if (config.isMavlinkUdpBridgeConfigChanged()){
             mavlinkUdpBridge.close();
-            if (config.getMavlinkUdpBridge() != SettingsCommon.MavlinkUdpBridge.disabled){
+            if (config.getMavlinkUdpBridge() != SettingsCommon.MavlinkUdpBridge.disabled
+                    || config.getMavlinkUdpBridge() != SettingsCommon.MavlinkUdpBridge.redirectFromControlDevice){
                 mavlinkUdpBridge.initialize();
             }
             config.mavlinkUdpBridgeConfigUpdated();

--- a/Server/src/de/droiddrone/server/Udp.java
+++ b/Server/src/de/droiddrone/server/Udp.java
@@ -235,6 +235,11 @@ public class Udp {
 					senders[0].sendPacket(packet.data);
 					break;
 				}
+			case UdpCommon.MavlinkRawPacket:
+				// controller <-> drone communication only
+				if (clientId == 0 && senders[1] != null) senders[1].sendPacket(packet.data);
+				if (clientId == 1 && senders[0] != null) senders[0].sendPacket(packet.data);
+			break;
 			default:
 				for (int i = 0; i < clientsCount; i++) {
 					if (i == clientId || senders[i] == null || !senders[i].isActive()) continue;


### PR DESCRIPTION
You can use this mode if the GCS is behind the NAT but on the same network as the control device. Mavlink packets are sent from the drone to the controller via the main UDP channel and then redirected to the local IP of GCS and vice versa.